### PR TITLE
meta_description should allow null

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -11,7 +11,7 @@ CREATE TABLE tx_dpnglossary_domain_model_term (
   term_mode            varchar(255)        DEFAULT ''   NOT NULL,
   term_link            varchar(255)        DEFAULT ''   NOT NULL,
   seo_title            varchar(255)        DEFAULT ''   NOT NULL,
-  meta_description     text                             NOT NULL,
+  meta_description     text,
   exclude_from_parsing tinyint(4) unsigned DEFAULT '0'  NOT NULL,
   case_sensitive       tinyint(4) unsigned DEFAULT '0'  NOT NULL,
   max_replacements     int(11)             DEFAULT '-1' NOT NULL,


### PR DESCRIPTION
meta_description is a exclude field and should allow null, otherwise it will generate a sql error if the user has not right to edit this field.

error message: 2: SQL error: 'Field 'meta_description' doesn't have a default value' (tx_dpnglossary_domain_model_term:NEW63a2ffbb82951134754683)